### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,9 +1,18 @@
+
 :root {
   --primary-color: #2563eb;
   --primary-dark: #1e40af;
   --text-color: #1f2937;
   --card-bg: #ffffff;
   --bg-gradient: linear-gradient(135deg, #f8fafc, #e2e8f0);
+}
+
+[data-theme="dark"] {
+  --primary-color: #2563eb;
+  --primary-dark: #1e40af;
+  --text-color: #f8fafc;
+  --card-bg: #1f2937;
+  --bg-gradient: linear-gradient(135deg, #1f2937, #111827);
 }
 
 body {
@@ -33,6 +42,23 @@ h1 {
   flex-direction: column;
   align-items: center;
 
+}
+
+.theme-toggle {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background-color: var(--primary-color);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.theme-toggle:hover {
+  background-color: var(--primary-dark);
 }
 
 * {

--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,10 @@ function App() {
   const [noticeMessageError, setNoticeMessageError] = useState("");
   const [noticeVisibleError, setNoticeVisibleError] = useState(false);
 
+  const [darkMode, setDarkMode] = useState(
+    () => localStorage.getItem("theme") === "dark"
+  );
+
   const handlePhoneChange = (value) => {
     setPhoneNumber(value);
     setWaLink("");
@@ -37,9 +41,19 @@ function App() {
     setShowMessage(!showMessage); // Toggle message box visibility
   };
 
+  const toggleDarkMode = () => {
+    setDarkMode((prev) => !prev);
+  };
+
   useEffect(() => {
     setNoticeVisibleGenerate(false);
   }, []);
+
+  useEffect(() => {
+    const theme = darkMode ? "dark" : "light";
+    document.documentElement.setAttribute("data-theme", theme);
+    localStorage.setItem("theme", theme);
+  }, [darkMode]);
 
   const generateLink = () => {
     if (phoneNumber) {
@@ -88,6 +102,9 @@ function App() {
 
   return (
     <div className="app">
+      <button className="theme-toggle" onClick={toggleDarkMode}>
+        {darkMode ? "Light Mode" : "Dark Mode"}
+      </button>
       <h1>
         <ReactTyped
           strings={["Send WhatsApp Message Without Saving the Number"]}


### PR DESCRIPTION
## Summary
- add persistent dark mode state and toggle button
- define theme variables for light and dark modes using data-theme attribute

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689962043570832d99490118e961c09b