### PR TITLE
feat: add message template management

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -120,6 +120,26 @@ textarea:focus {
   flex: 1;
 }
 
+.template-controls {
+  display: flex;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.template-controls select {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+}
+
+.template-controls select:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.3);
+}
+
 .floating-notice {
   position: fixed;
   bottom: 20px;

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,8 @@ function App() {
   const [waLink, setWaLink] = useState("");
   const [message, setMessage] = useState(""); // State for message text
   const [showMessage, setShowMessage] = useState(false); // State for toggling message box
+  const [templates, setTemplates] = useState([]); // Saved message templates
+  const [selectedTemplate, setSelectedTemplate] = useState("");
 
   const [noticeMessageGenerate, setNoticeMessageGenerate] = useState("");
   const [noticeVisibleGenerate, setNoticeVisibleGenerate] = useState(false);
@@ -39,7 +41,15 @@ function App() {
 
   useEffect(() => {
     setNoticeVisibleGenerate(false);
+    const storedTemplates = JSON.parse(
+      localStorage.getItem("templates") || "[]"
+    );
+    setTemplates(storedTemplates);
   }, []);
+
+  useEffect(() => {
+    localStorage.setItem("templates", JSON.stringify(templates));
+  }, [templates]);
 
   const generateLink = () => {
     if (phoneNumber) {
@@ -86,6 +96,32 @@ function App() {
     setShowMessage(false);
   };
 
+  const saveTemplate = () => {
+    if (message.trim() !== "") {
+      setTemplates([...templates, message]);
+    }
+  };
+
+  const handleTemplateSelect = (event) => {
+    const index = event.target.value;
+    setSelectedTemplate(index);
+    const template = templates[index];
+    setMessage(template);
+    if (!showMessage) {
+      setShowMessage(true);
+    }
+  };
+
+  const deleteTemplate = () => {
+    if (selectedTemplate !== "") {
+      const newTemplates = templates.filter(
+        (_, idx) => idx !== parseInt(selectedTemplate)
+      );
+      setTemplates(newTemplates);
+      setSelectedTemplate("");
+    }
+  };
+
   return (
     <div className="app">
       <h1>
@@ -120,6 +156,33 @@ function App() {
             }`}
           ></i>
         </button>
+        {templates.length > 0 && (
+          <div className="template-controls">
+            <select
+              value={selectedTemplate}
+              onChange={handleTemplateSelect}
+            >
+              <option value="">Select a template</option>
+              {templates.map((temp, idx) => (
+                <option key={idx} value={idx}>
+                  {temp}
+                </option>
+              ))}
+            </select>
+            <button
+              className="btn"
+              onClick={deleteTemplate}
+              disabled={selectedTemplate === ""}
+            >
+              Delete Template
+            </button>
+          </div>
+        )}
+        {showMessage && (
+          <button className="btn" onClick={saveTemplate}>
+            Save Current Message
+          </button>
+        )}
         <button className="genBtn btn" onClick={generateLink}>
           Generate WhatsApp Link
         </button>


### PR DESCRIPTION
## Summary
- allow saving and reusing message templates via localStorage
- add UI for selecting and deleting message templates
- style template dropdown for consistent appearance

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68996203d3d4832d8b9e6afcdd0317d1